### PR TITLE
fix: Add fallback for name in `addOpened`

### DIFF
--- a/src/stores/db.js
+++ b/src/stores/db.js
@@ -462,7 +462,7 @@ export const useDBStore = defineStore("db", () => {
       if (currentConf?.["name"] !== currentModuleConf?.["name"]) {
         name = `${currentModuleConf["name"]} / ${currentConf?.["name"]}`
       }
-      //If not found a name we set it to an empty string
+      //If not found a name we set it to the route name or an empty string
       if (!name) {
         name = route["name"] ? route["name"] : "";
       }

--- a/src/stores/db.js
+++ b/src/stores/db.js
@@ -463,9 +463,10 @@ export const useDBStore = defineStore("db", () => {
         name = `${currentModuleConf["name"]} / ${currentConf?.["name"]}`
       }
       //If not found a name we set it to an empty string
-      if (name === undefined) {
-        name = "";
+      if (!name) {
+        name = route["name"] ? route["name"] : "";
       }
+
     }
     let group = currentConf?.["group"]
     if (!group && route.params['group']) {

--- a/src/stores/db.js
+++ b/src/stores/db.js
@@ -51,7 +51,7 @@ function adminTreeLayer(itemList, parent) {
     if(conf['nodeType'] === "group" && conf["moduleGroups"]?.length === 0){
       conf["display"] = "hidden"
     }
-    
+
 
     // set index as sortindex if missing
     if (!Object.keys(conf).includes("sortIndex") || conf["sortIndex"] === 0) {
@@ -325,7 +325,7 @@ export const useDBStore = defineStore("db", () => {
       }else{
         nestedGroups.push(prefixed_group)
       }
-      
+
     }
 
     let itemList = []
@@ -461,6 +461,10 @@ export const useDBStore = defineStore("db", () => {
       name = currentConf?.["name"]
       if (currentConf?.["name"] !== currentModuleConf?.["name"]) {
         name = `${currentModuleConf["name"]} / ${currentConf?.["name"]}`
+      }
+      //If not found a name we set it to an empty string
+      if (name === undefined) {
+        name = "";
       }
     }
     let group = currentConf?.["group"]


### PR DESCRIPTION
If no name found in moduleconf this will fail, because the name is `undefined`. https://github.com/viur-framework/vi-vue-components/blob/20127ecd3f563d28cc01defb3e8f9db2205794eb/src/main/TheMainScreenTabbarItem.vue#L17


